### PR TITLE
Stabilize JPA integration tests

### DIFF
--- a/org.myshop.shop.dao.jpa.it/src/test/java/org/myshop/shop/dao/jpa/it/BaseItemAwareIntegrationTest.java
+++ b/org.myshop.shop.dao.jpa.it/src/test/java/org/myshop/shop/dao/jpa/it/BaseItemAwareIntegrationTest.java
@@ -1,0 +1,118 @@
+package org.myshop.shop.dao.jpa.it;
+
+import java.util.List;
+
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.Persistence;
+
+import org.junit.After;
+import org.myshop.shop.dao.ItemCategoryDao;
+import org.myshop.shop.dao.ItemDao;
+import org.myshop.shop.dao.ProductGroupDao;
+import org.myshop.shop.dao.jpa.JpaItemCategoryDao;
+import org.myshop.shop.dao.jpa.JpaItemDao;
+import org.myshop.shop.dao.jpa.JpaProductGroupDao;
+import org.myshop.shop.model.Item;
+import org.myshop.shop.model.ItemCategory;
+import org.myshop.shop.model.ProductGroup;
+
+public class BaseItemAwareIntegrationTest {
+
+	protected static final String TEST_ITEM_CATEGORY_ID = "test_item_category_id";
+	protected static final String TEST_ITEM_CATEGORY_NAME = "test_item_category_name";
+	protected static final String TEST_ITEM_CATEGORY_DESCRIPTION = "test_item_category_description";
+
+	protected static final String TEST_PRODUCT_GROUP_ID = "test_product_group_id";
+	protected static final String TEST_PRODUCT_GROUP_DESCRIPTION = "test_product_group_description";
+
+	protected static final String TEST_ITEM_ID = "test_item_id";
+	protected static final String TEST_ITEM_NAME = "test_item_name";
+	protected static final String TEST_ITEM_DESCRIPTION = "test_item_description";
+	protected static final float TEST_ITEM_SALES_PRICE = 123;
+	protected static final float TEST_ITEM_PURCHASE_PRICE = 234;
+
+	protected static final String TEST_ITEM_ID_2 = "test_item_id_2";
+	protected static final String TEST_ITEM_NAME_2 = "test_item_name_2";
+	protected static final String TEST_ITEM_DESCRIPTION_2 = "test_item_description_2";
+	protected static final float TEST_ITEM_SALES_PRICE_2 = 345;
+	protected static final float TEST_ITEM_PURCHASE_PRICE_2 = 456;
+
+	protected EntityManagerFactory factory;
+
+	protected ItemDao itemDao;
+	protected ItemCategoryDao itemCategoryDao;
+	protected ProductGroupDao productGroupDao;
+
+	public void setup() {
+		factory = Persistence.createEntityManagerFactory("myshopDB");
+
+		itemDao = new JpaItemDao(factory);
+		itemCategoryDao = new JpaItemCategoryDao(factory);
+		productGroupDao = new JpaProductGroupDao(factory);
+
+		initTestItem();
+	}
+
+	@After
+	public void cleanup() {
+		System.out.println("super cleanup, start");
+
+		clearTestItem();
+		
+		System.out.println("super cleanup, end");
+	}
+
+	private void initTestItem() {
+		ItemCategory itemCategory = new ItemCategory();
+		itemCategory.setId(TEST_ITEM_CATEGORY_ID);
+		itemCategory.setName(TEST_ITEM_CATEGORY_NAME);
+		itemCategory.setDescription(TEST_ITEM_CATEGORY_DESCRIPTION);
+		itemCategoryDao.create(itemCategory);
+
+		ProductGroup productGroup = new ProductGroup();
+		productGroup.setId(TEST_PRODUCT_GROUP_ID);
+		productGroup.setDescription(TEST_PRODUCT_GROUP_DESCRIPTION);
+		productGroup.setItemCategory(itemCategory);
+		productGroupDao.create(productGroup);
+
+		Item item = new Item();
+		item.setId(TEST_ITEM_ID);
+		item.setName(TEST_ITEM_NAME);
+		item.setDescription(TEST_ITEM_DESCRIPTION);
+		item.setItemCategory(itemCategory);
+		item.setProductGroup(productGroup);
+		item.setSalesPrice(TEST_ITEM_SALES_PRICE);
+		item.setPurchasePrice(TEST_ITEM_PURCHASE_PRICE);
+		itemDao.create(item);
+
+		item = new Item();
+		item.setId(TEST_ITEM_ID_2);
+		item.setName(TEST_ITEM_NAME_2);
+		item.setDescription(TEST_ITEM_DESCRIPTION_2);
+		item.setItemCategory(itemCategory);
+		item.setProductGroup(productGroup);
+		item.setSalesPrice(TEST_ITEM_SALES_PRICE_2);
+		item.setPurchasePrice(TEST_ITEM_PURCHASE_PRICE_2);
+		itemDao.create(item);
+	}
+
+	private void clearTestItem() {
+		List<Item> itemList = itemDao.read();
+		
+		System.out.println(itemList);
+		
+		for (Item item : itemList) {
+			itemDao.delete(item);
+		}
+
+		List<ProductGroup> productGroupList = productGroupDao.read();
+		for (ProductGroup productGroup : productGroupList) {
+			productGroupDao.delete(productGroup);
+		}
+
+		List<ItemCategory> itemCategoryList = itemCategoryDao.read();
+		for (ItemCategory itemCategory : itemCategoryList) {
+			itemCategoryDao.delete(itemCategory);
+		}
+	}
+}

--- a/org.myshop.shop.dao.jpa.it/src/test/java/org/myshop/shop/dao/jpa/it/JpaItemCategoryDaoIntegrationIT.java
+++ b/org.myshop.shop.dao.jpa.it/src/test/java/org/myshop/shop/dao/jpa/it/JpaItemCategoryDaoIntegrationIT.java
@@ -9,6 +9,7 @@ import java.util.List;
 import javax.persistence.EntityManagerFactory;
 import javax.persistence.Persistence;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.myshop.shop.dao.jpa.JpaItemCategoryDao;
@@ -24,6 +25,15 @@ public class JpaItemCategoryDaoIntegrationIT {
 	public void setup() {	
 		factory = Persistence.createEntityManagerFactory("myshopDB");
 		itemCategoryDao = new JpaItemCategoryDao(factory);
+	}
+	
+	@After
+	public void cleanup() {
+		List<ItemCategory> itemCategoryList = itemCategoryDao.read();
+		
+		for (ItemCategory itemCategory : itemCategoryList) {
+			itemCategoryDao.delete(itemCategory);
+		}
 	}
 	
 	@Test

--- a/org.myshop.shop.dao.jpa.it/src/test/java/org/myshop/shop/dao/jpa/it/JpaItemDaoIntegrationIT.java
+++ b/org.myshop.shop.dao.jpa.it/src/test/java/org/myshop/shop/dao/jpa/it/JpaItemDaoIntegrationIT.java
@@ -19,7 +19,7 @@ import org.myshop.shop.model.Item;
 import org.myshop.shop.model.ItemCategory;
 import org.myshop.shop.model.ProductGroup;
 
-public class JpaItemDaoIntegrationITT {
+public class JpaItemDaoIntegrationIT {
 
 	private JpaProductGroupDao productGroupDao;
 	private JpaItemCategoryDao itemCategoryDao;

--- a/org.myshop.shop.dao.jpa.it/src/test/java/org/myshop/shop/dao/jpa/it/JpaItemDaoIntegrationITT.java
+++ b/org.myshop.shop.dao.jpa.it/src/test/java/org/myshop/shop/dao/jpa/it/JpaItemDaoIntegrationITT.java
@@ -9,6 +9,7 @@ import java.util.List;
 import javax.persistence.EntityManagerFactory;
 import javax.persistence.Persistence;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.myshop.shop.dao.jpa.JpaItemCategoryDao;
@@ -18,7 +19,7 @@ import org.myshop.shop.model.Item;
 import org.myshop.shop.model.ItemCategory;
 import org.myshop.shop.model.ProductGroup;
 
-public class JpaItemDaoIntegrationIT {
+public class JpaItemDaoIntegrationITT {
 
 	private JpaProductGroupDao productGroupDao;
 	private JpaItemCategoryDao itemCategoryDao;
@@ -31,6 +32,24 @@ public class JpaItemDaoIntegrationIT {
 		productGroupDao = new JpaProductGroupDao(factory);
 		itemCategoryDao = new JpaItemCategoryDao(factory);
 		itemDao = new JpaItemDao(factory);
+	}
+	
+	@After
+	public void cleanup() {
+		List<Item> itemList = itemDao.read();
+		for (Item item : itemList) {
+			itemDao.delete(item);
+		}
+		
+		List<ProductGroup> productGroupList = productGroupDao.read();
+		for (ProductGroup productGroup : productGroupList) {
+			productGroupDao.delete(productGroup);
+		}
+		
+		List<ItemCategory> itemCategoryList = itemCategoryDao.read();
+		for (ItemCategory itemCategory : itemCategoryList) {
+			itemCategoryDao.delete(itemCategory);
+		}
 	}
 	
 	@Test

--- a/org.myshop.shop.dao.jpa.it/src/test/java/org/myshop/shop/dao/jpa/it/JpaPostedPurchaseOrderLineDaoIntegrationIT.java
+++ b/org.myshop.shop.dao.jpa.it/src/test/java/org/myshop/shop/dao/jpa/it/JpaPostedPurchaseOrderLineDaoIntegrationIT.java
@@ -6,33 +6,27 @@ import static org.junit.Assert.assertNull;
 
 import java.util.List;
 
-import javax.persistence.EntityManagerFactory;
-import javax.persistence.Persistence;
-
 import org.junit.Before;
 import org.junit.Test;
-import org.myshop.shop.dao.jpa.JpaItemDao;
 import org.myshop.shop.dao.jpa.JpaPostedPurchaseOrderLineDao;
 import org.myshop.shop.model.Item;
 import org.myshop.shop.model.PostedPurchaseOrderLine;
 
-public class JpaPostedPurchaseOrderLineDaoIntegrationIT {
+public class JpaPostedPurchaseOrderLineDaoIntegrationIT extends BaseItemAwareIntegrationTest {
 
-	private JpaItemDao itemDao;
 	private JpaPostedPurchaseOrderLineDao postedPurchaseOrderLineDao;
-	private EntityManagerFactory factory;
 	
 	@Before
 	public void setup() {
-		factory = Persistence.createEntityManagerFactory("myshopDB");
-		itemDao = new JpaItemDao(factory);
+		super.setup();
+		
 		postedPurchaseOrderLineDao = new JpaPostedPurchaseOrderLineDao(factory);
 	}
 	
 	@Test
 	public void testCreate() {
 		
-		Item item = itemDao.get("test_item_id"); 	
+		Item item = itemDao.get(TEST_ITEM_ID); 	
 		
 		PostedPurchaseOrderLine line = new PostedPurchaseOrderLine();
 		
@@ -49,7 +43,7 @@ public class JpaPostedPurchaseOrderLineDaoIntegrationIT {
 	@Test
 	public void testRead() {
 		
-		Item item = itemDao.get("test_item_id");
+		Item item = itemDao.get(TEST_ITEM_ID);
 		
 		PostedPurchaseOrderLine line = new PostedPurchaseOrderLine();
 		
@@ -79,7 +73,7 @@ public class JpaPostedPurchaseOrderLineDaoIntegrationIT {
 	@Test
 	public void testGet() {
 		
-		Item item = itemDao.get("test_item_id");
+		Item item = itemDao.get(TEST_ITEM_ID);
 		
 		PostedPurchaseOrderLine line = new PostedPurchaseOrderLine();
 		
@@ -96,7 +90,7 @@ public class JpaPostedPurchaseOrderLineDaoIntegrationIT {
 		
 		assertNotNull(line);
 		assertEquals(line.getId(), "test_id_get");
-		assertEquals(line.getItem().getId(), "test_item_id");
+		assertEquals(line.getItem().getId(), TEST_ITEM_ID);
 		assertEquals(line.getLineNumber(), 123);
 		assertEquals(0f, line.getPrice(), 123.456f);
 		assertEquals(line.getQuantity(), 123);
@@ -106,8 +100,9 @@ public class JpaPostedPurchaseOrderLineDaoIntegrationIT {
 	@Test
 	public void testUpdate() {
 		
-		Item item = itemDao.get("test_item_id");
-		Item itemToUpdate = itemDao.get("item_id_get");
+		Item item = itemDao.get(TEST_ITEM_ID);
+		
+		Item itemToUpdate = itemDao.get(TEST_ITEM_ID_2);
 		
 		PostedPurchaseOrderLine line = new PostedPurchaseOrderLine();
 		
@@ -129,7 +124,7 @@ public class JpaPostedPurchaseOrderLineDaoIntegrationIT {
 		line = postedPurchaseOrderLineDao.update(line);
 		
 		assertEquals(line.getId(), "test_id_update");
-		assertEquals(line.getItem().getId(), "item_id_get");
+		assertEquals(line.getItem().getId(), TEST_ITEM_ID_2);
 		assertEquals(line.getLineNumber(), 321);
 		assertEquals(0f, line.getPrice(), 123.789f);
 		assertEquals(line.getQuantity(), 321);
@@ -139,7 +134,7 @@ public class JpaPostedPurchaseOrderLineDaoIntegrationIT {
 	@Test
 	public void testDelete() {
 		
-		Item item = itemDao.get("test_item_id");
+		Item item = itemDao.get(TEST_ITEM_ID);
 		
 		PostedPurchaseOrderLine line = new PostedPurchaseOrderLine();
 		
@@ -158,4 +153,5 @@ public class JpaPostedPurchaseOrderLineDaoIntegrationIT {
 		
 		assertNull(line);
 	}
+	
 }

--- a/org.myshop.shop.dao.jpa.it/src/test/java/org/myshop/shop/dao/jpa/it/JpaPostedSalesOrderLineDaoIntegrationIT.java
+++ b/org.myshop.shop.dao.jpa.it/src/test/java/org/myshop/shop/dao/jpa/it/JpaPostedSalesOrderLineDaoIntegrationIT.java
@@ -6,26 +6,20 @@ import static org.junit.Assert.assertNull;
 
 import java.util.List;
 
-import javax.persistence.EntityManagerFactory;
-import javax.persistence.Persistence;
-
 import org.junit.Before;
 import org.junit.Test;
-import org.myshop.shop.dao.jpa.JpaItemDao;
 import org.myshop.shop.dao.jpa.JpaPostedSalesOrderLineDao;
 import org.myshop.shop.model.Item;
 import org.myshop.shop.model.PostedSalesOrderLine;
 
-public class JpaPostedSalesOrderLineDaoIntegrationIT {
+public class JpaPostedSalesOrderLineDaoIntegrationIT extends BaseItemAwareIntegrationTest{
 
-	private JpaItemDao itemDao;
 	private JpaPostedSalesOrderLineDao postedSalesOrderLineDao;
-	private EntityManagerFactory factory;
 	
 	@Before
 	public void setup() {
-		factory = Persistence.createEntityManagerFactory("myshopDB");
-		itemDao = new JpaItemDao(factory);
+		super.setup();
+		
 		postedSalesOrderLineDao = new JpaPostedSalesOrderLineDao(factory);
 	}
 	
@@ -107,7 +101,7 @@ public class JpaPostedSalesOrderLineDaoIntegrationIT {
 	public void testUpdate() {
 		
 		Item item = itemDao.get("test_item_id");
-		Item itemToUpdate = itemDao.get("item_id_get");
+		Item itemToUpdate = itemDao.get("test_item_id_2");
 		
 		PostedSalesOrderLine line = new PostedSalesOrderLine();
 		
@@ -129,7 +123,7 @@ public class JpaPostedSalesOrderLineDaoIntegrationIT {
 		line = postedSalesOrderLineDao.update(line);
 		
 		assertEquals(line.getId(), "test_id_update");
-		assertEquals(line.getItem().getId(), "item_id_get");
+		assertEquals(line.getItem().getId(), "test_item_id_2");
 		assertEquals(line.getLineNumber(), 321);
 		assertEquals(0f, line.getPrice(), 123.789f);
 		assertEquals(line.getQuantity(), 321);

--- a/org.myshop.shop.dao.jpa.it/src/test/java/org/myshop/shop/dao/jpa/it/JpaProductGroupDaoIntegrationIT.java
+++ b/org.myshop.shop.dao.jpa.it/src/test/java/org/myshop/shop/dao/jpa/it/JpaProductGroupDaoIntegrationIT.java
@@ -9,6 +9,7 @@ import java.util.List;
 import javax.persistence.EntityManagerFactory;
 import javax.persistence.Persistence;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.myshop.shop.dao.jpa.JpaItemCategoryDao;
@@ -28,6 +29,19 @@ public class JpaProductGroupDaoIntegrationIT {
 		factory = Persistence.createEntityManagerFactory("myshopDB");
 		productGroupDao = new JpaProductGroupDao(factory);
 		itemCategoryDao = new JpaItemCategoryDao(factory);
+	}
+	
+	@After
+	public void cleanup() {
+		List<ProductGroup> productGroupList = productGroupDao.read();
+		for (ProductGroup productGroup : productGroupList) {
+			productGroupDao.delete(productGroup);
+		}
+		
+		List<ItemCategory> itemCategoryList = itemCategoryDao.read();
+		for (ItemCategory itemCategory : itemCategoryList) {
+			itemCategoryDao.delete(itemCategory);
+		}
 	}
 	
 	@Test

--- a/org.myshop.shop.dao.jpa.it/src/test/java/org/myshop/shop/dao/jpa/it/JpaPurchaseOrderLineDaoIntegrationIT.java
+++ b/org.myshop.shop.dao.jpa.it/src/test/java/org/myshop/shop/dao/jpa/it/JpaPurchaseOrderLineDaoIntegrationIT.java
@@ -6,31 +6,27 @@ import static org.junit.Assert.assertNull;
 
 import java.util.List;
 
-import javax.persistence.EntityManagerFactory;
-import javax.persistence.Persistence;
-
 import org.junit.Before;
 import org.junit.Test;
-import org.myshop.shop.dao.jpa.JpaItemDao;
 import org.myshop.shop.dao.jpa.JpaPurchaseOrderLineDao;
 import org.myshop.shop.model.Item;
 import org.myshop.shop.model.PurchaseOrderLine;
 
-public class JpaPurchaseOrderLineDaoIntegrationIT {
+public class JpaPurchaseOrderLineDaoIntegrationIT extends BaseItemAwareIntegrationTest {
 
-	private JpaItemDao itemDao;
 	private JpaPurchaseOrderLineDao purchaseOrderLineDao;
-	private EntityManagerFactory factory;
 	
 	@Before
 	public void setup() {
-		factory = Persistence.createEntityManagerFactory("myshopDB");
-		itemDao = new JpaItemDao(factory);
+		super.setup();
+		
 		purchaseOrderLineDao = new JpaPurchaseOrderLineDao(factory);
 	}
 	
 	@Test
 	public void testCreate() {
+		
+		System.out.println("testCreate, begin");
 		
 		Item item = itemDao.get("test_item_id"); 	
 		
@@ -44,6 +40,8 @@ public class JpaPurchaseOrderLineDaoIntegrationIT {
 		line.setAmmount(123);
 		
 		purchaseOrderLineDao.create(line);
+		
+		System.out.println("testCreate, end");
 	}
 	
 	@Test
@@ -106,8 +104,13 @@ public class JpaPurchaseOrderLineDaoIntegrationIT {
 	@Test
 	public void testUpdate() {
 		
+		List<Item> itemList = itemDao.read();
+		
+		System.out.println("===============================================================================================================================================");
+		System.out.println("item list before update test: " + itemList.size());
+		
 		Item item = itemDao.get("test_item_id");
-		Item itemToUpdate = itemDao.get("item_id_get");
+		Item itemToUpdate = itemDao.get("test_item_id_2");
 		
 		PurchaseOrderLine line = new PurchaseOrderLine();
 		
@@ -129,7 +132,7 @@ public class JpaPurchaseOrderLineDaoIntegrationIT {
 		line = purchaseOrderLineDao.update(line);
 		
 		assertEquals(line.getId(), "test_id_update");
-		assertEquals(line.getItem().getId(), "item_id_get");
+		assertEquals(line.getItem().getId(), "test_item_id_2");
 		assertEquals(line.getLineNumber(), 321);
 		assertEquals(0f, line.getPrice(), 123.789f);
 		assertEquals(line.getQuantity(), 321);

--- a/org.myshop.shop.dao.jpa.it/src/test/java/org/myshop/shop/dao/jpa/it/JpaSalesOrderLineDaoIntegrationIT.java
+++ b/org.myshop.shop.dao.jpa.it/src/test/java/org/myshop/shop/dao/jpa/it/JpaSalesOrderLineDaoIntegrationIT.java
@@ -6,26 +6,20 @@ import static org.junit.Assert.assertNull;
 
 import java.util.List;
 
-import javax.persistence.EntityManagerFactory;
-import javax.persistence.Persistence;
-
 import org.junit.Before;
 import org.junit.Test;
-import org.myshop.shop.dao.jpa.JpaItemDao;
 import org.myshop.shop.dao.jpa.JpaSalesOrderLineDao;
 import org.myshop.shop.model.Item;
 import org.myshop.shop.model.SalesOrderLine;
 
-public class JpaSalesOrderLineDaoIntegrationIT {
+public class JpaSalesOrderLineDaoIntegrationIT extends BaseItemAwareIntegrationTest {
 
-	private JpaItemDao itemDao;
 	private JpaSalesOrderLineDao salesOrderLineDao;
-	private EntityManagerFactory factory;
 	
 	@Before
 	public void setup() {
-		factory = Persistence.createEntityManagerFactory("myshopDB");
-		itemDao = new JpaItemDao(factory);
+		super.setup();
+		
 		salesOrderLineDao = new JpaSalesOrderLineDao(factory);
 	}
 	
@@ -107,7 +101,7 @@ public class JpaSalesOrderLineDaoIntegrationIT {
 	public void testUpdate() {
 		
 		Item item = itemDao.get("test_item_id");
-		Item itemToUpdate = itemDao.get("item_id_get");
+		Item itemToUpdate = itemDao.get("test_item_id_2");
 		
 		SalesOrderLine line = new SalesOrderLine();
 		
@@ -129,7 +123,7 @@ public class JpaSalesOrderLineDaoIntegrationIT {
 		line = salesOrderLineDao.update(line);
 		
 		assertEquals(line.getId(), "test_id_update");
-		assertEquals(line.getItem().getId(), "item_id_get");
+		assertEquals(line.getItem().getId(), "test_item_id_2");
 		assertEquals(line.getLineNumber(), 321);
 		assertEquals(0f, line.getPrice(), 123.789f);
 		assertEquals(line.getQuantity(), 321);

--- a/org.myshop.shop.dao.jpa.it/src/test/java/org/myshop/shop/dao/jpa/it/JpaVendorDaoIntegrationITT.java
+++ b/org.myshop.shop.dao.jpa.it/src/test/java/org/myshop/shop/dao/jpa/it/JpaVendorDaoIntegrationITT.java
@@ -14,7 +14,7 @@ import org.junit.Test;
 import org.myshop.shop.dao.jpa.JpaVendorDao;
 import org.myshop.shop.model.Vendor;
 
-public class JpaVendorDaoIntegrationIT {
+public class JpaVendorDaoIntegrationITT {
 
 	private JpaVendorDao vendorDao;
 	private EntityManagerFactory factory;


### PR DESCRIPTION
There was some degree of instability of JPA integration tests. They were passing on Windows and failing on MacOS. The goal of this PR is to bring in some stability to the tests. 