### PR TITLE
Used JPA queries instead of native ones

### DIFF
--- a/org.myshop.shop.dao.jpa/src/main/java/org/myshop/shop/dao/jpa/JpaItemCategoryDao.java
+++ b/org.myshop.shop.dao.jpa/src/main/java/org/myshop/shop/dao/jpa/JpaItemCategoryDao.java
@@ -15,7 +15,7 @@ public class JpaItemCategoryDao implements ItemCategoryDao{
 	private EntityManager entityManager;
 	private EntityManagerFactory factory;
 	
-	protected final static String READ_QUERY = "SELECT * FROM itemCategory";
+	public final static String READ_QUERY_NAME = "itemCategory.read";
 	
 	public JpaItemCategoryDao(EntityManagerFactory factory) {
 		this.factory = factory;
@@ -37,7 +37,7 @@ public class JpaItemCategoryDao implements ItemCategoryDao{
 		List<ItemCategory> itemCategoryList = new ArrayList<ItemCategory>();
 		
 		@SuppressWarnings("unchecked")
-		List<ItemCategoryEntity> entityList = entityManager.createNativeQuery(READ_QUERY, ItemCategoryEntity.class).getResultList();
+		List<ItemCategoryEntity> entityList = entityManager.createNamedQuery(READ_QUERY_NAME).getResultList();
 		
 		for(int i=0; i < entityList.size(); i++) {
 			itemCategoryList.add(entityList.get(i).toItemCategory());

--- a/org.myshop.shop.dao.jpa/src/test/java/org/myshop/shop/dao/jpa/JpaItemCategoryDaoTest.java
+++ b/org.myshop.shop.dao.jpa/src/test/java/org/myshop/shop/dao/jpa/JpaItemCategoryDaoTest.java
@@ -62,7 +62,7 @@ public class JpaItemCategoryDaoTest {
 		
 		when(entityManagerMock.getTransaction()).thenReturn(entityTransactionMock);
 		when(factoryMock.createEntityManager()).thenReturn(entityManagerMock);
-		when(entityManagerMock.createNativeQuery(JpaItemCategoryDao.READ_QUERY, ItemCategoryEntity.class)).thenReturn(queryMock);
+		when(entityManagerMock.createNamedQuery(JpaItemCategoryDao.READ_QUERY_NAME)).thenReturn(queryMock);
 		when(queryMock.getResultList()).thenReturn(entityListMock);
 		
 		when(entityManagerMock.find(ItemCategoryEntity.class, TEST_ITEM_CATEGORY_ID)).thenReturn(itemCategoryEntityMock);
@@ -103,7 +103,7 @@ public class JpaItemCategoryDaoTest {
 	public void testRead() {
 		List<ItemCategory> itemCategoryListMock = itemCategoryDaoMock.read();
 		
-		verify(entityManagerMock).createNativeQuery(JpaItemCategoryDao.READ_QUERY, ItemCategoryEntity.class);
+		verify(entityManagerMock).createNamedQuery(JpaItemCategoryDao.READ_QUERY_NAME);
 		verify(queryMock).getResultList();
 		
 		assertNotNull(itemCategoryListMock);

--- a/org.myshop.shop.jpa.model/src/main/java/org/org/myshop/shop/jpa/model/ItemCategoryEntity.java
+++ b/org.myshop.shop.jpa.model/src/main/java/org/org/myshop/shop/jpa/model/ItemCategoryEntity.java
@@ -2,12 +2,17 @@ package org.org.myshop.shop.jpa.model;
 
 import javax.persistence.Entity;
 import javax.persistence.Id;
+import javax.persistence.NamedQueries;
+import javax.persistence.NamedQuery;
 import javax.persistence.Table;
 
 import org.myshop.shop.model.ItemCategory;
 
 @Entity
 @Table(name = "itemCategory")
+@NamedQueries({
+	@NamedQuery(name="itemCategory.read", query="SELECT itemCategory FROM ItemCategoryEntity itemCategory")	
+})
 public class ItemCategoryEntity {
 
 	@Id


### PR DESCRIPTION
In JPA implementation native queries are used. It is better to replace them with named, JPA queries. 
This PR shows how this could be done. 